### PR TITLE
Fix pane comments typos in tmux config

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -81,9 +81,9 @@ set -g message-style fg=colour244,bg=colour235,bright
 # Set the pane border style for the currently active pane.
 set -g pane-active-border-style fg=colour64,bg=colour234
 
-# Set the pane border style for paneas aside from the active pane
+# Set the pane border style for panes aside from the active pane
 set -g pane-border-style fg=colour235,bg=colour235
-#### end pain-* ####
+#### end pane-* ####
 
 ####
 #


### PR DESCRIPTION
## Summary
- fix typos in tmux pane comment block

## Testing
- `npm test`
- `tmux -f .tmux.conf -L test start-server && tmux -f .tmux.conf -L test kill-server` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a532e7a548832cbd18489dd6110fb6