### PR TITLE
chore: guard PMS sourcing

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -22,4 +22,8 @@
 [[ -f ~/.env.local ]] && source ~/.env.local
 [[ -f ~/.env.zsh.local ]] && source ~/.env.zsh.local
 
-source $PMS/pms.sh zsh
+if [[ -n "$PMS" && -f "$PMS/pms.sh" ]]; then
+    source "$PMS/pms.sh" zsh
+else
+    print -u2 "Warning: PMS script not found; skipping PMS integration"
+fi


### PR DESCRIPTION
## Summary
- guard PMS init with environment and file checks

## Testing
- `zsh -n .zshrc`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a53437e348832cb5192630abc1ea74